### PR TITLE
Fix Windows x64 with x86 JVM

### DIFF
--- a/src/main/java/com/codebrig/journey/JourneyLoader.java
+++ b/src/main/java/com/codebrig/journey/JourneyLoader.java
@@ -75,6 +75,8 @@ public class JourneyLoader extends URLClassLoader {
                 } else {
                     is64bit = (System.getProperty("os.arch").contains("64"));
                 }
+                if (System.getProperty("sun.arch.data.model").equals("32"))
+                    is64Bit = false; // Can't load 64bit DLLs on 32bit JVM
                 if (is64bit) {
                     providerName = "windows_64";
                     jcefName = "win64";


### PR DESCRIPTION
Adds a check for using the x86 version of Java on x64 bit Windows.
Fixes #35 